### PR TITLE
Anyfi.net integration

### DIFF
--- a/package/anyfi/Makefile
+++ b/package/anyfi/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+ANYFI_TARGET := $(ARCH)-linux-$(subst C,c,$(LIBC))-$(LIBCV)
+
+PKG_NAME     := anyfi
+PKG_VERSION  := 1.1.0
+PKG_RELEASE  := 1
+
+PKG_SOURCE     := anyfimac-$(PKG_VERSION)-$(ANYFI_TARGET).tar.bz2
+PKG_SOURCE_URL := http://anyfi.net/download
+PKG_BUILD_DIR  := $(BUILD_DIR)/anyfimac-$(PKG_VERSION)-$(ANYFI_TARGET)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/anyfi
+  SECTION  := net
+  CATEGORY := Network
+  TITLE    := Anyfi.net - The Open Wi-Fi Mobility Platform
+  URL      := http://anyfi.net
+  DEPENDS  := +kmod-tun +librt
+endef
+
+define Package/anyfi/description
+	Anyfi.net binaries and integration scripts.
+endef
+
+define Build/Configure
+	@echo "Nothing to do - Anyfi.net software comes pre-built."
+endef
+
+define Build/Compile
+	@echo "Nothing to do - Anyfi.net software comes pre-built."
+endef
+
+define Package/anyfi/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/anyfimac $(1)/sbin
+	$(LN) anyfimac $(1)/sbin/anyfid
+	$(LN) anyfimac $(1)/sbin/myfid
+	$(INSTALL_DIR) $(1)/bin
+	$(LN) ../sbin/anyfimac $(1)/bin/anyfidctl
+	$(LN) ../sbin/anyfimac $(1)/bin/myfidctl
+	$(INSTALL_DIR) $(1)/lib/wifi
+	$(INSTALL_BIN) ./files/anyfi.sh $(1)/lib/wifi
+endef
+
+$(eval $(call BuildPackage,anyfi))

--- a/package/anyfi/files/anyfi.sh
+++ b/package/anyfi/files/anyfi.sh
@@ -1,0 +1,543 @@
+#!/bin/sh
+#
+# Copyright (C) 2013 Anyfi Networks AB.
+#
+# Introduction to Anyfi.net
+# =========================
+#
+# Anyfi.net is an access point software extension that makes every Wi-Fi network
+# accessible through every Wi-Fi access point. The user experience is completely
+# seamless; if you have previously connected to a Wi-Fi network locally your
+# device will automatically connect to the same network remotely whenever you
+# come within range of another Anyfi.net enabled access point.
+#
+# Key features/properties:
+#
+#  * You don't need to install any software on the device; all the magic is on
+#    the access point side. From the device point of view it's all standard
+#    Wi-Fi.
+#
+#  * There is no manual registration step. When you connect your device to your
+#    home Wi-Fi network it's automatically registered for remote access to that
+#    network.
+#
+#  * Mobile devices "see" the home Wi-Fi SSID and are authenticated using the
+#    same Wi-Fi security mechanism and credentials that are used to authenticate
+#    devices locally. This is what makes authentication completely seamless.
+#
+#  * The Wi-Fi protocol is tunneled over IP from the visited access point to the
+#    home access point. This means that the encryption keys are derived only in
+#    the mobile device and in the trusted home access point, ensuring end-to-end
+#    security even if an attacker is in control of the visited access point. You
+#    can think of it as an automatic Wi-Fi based VPN of sorts.
+#
+#  * Since mobile devices connect to their home access points through a Wi-Fi
+#    over IP tunnel they are assigned IP addresses by the home network. This
+#    ensures seamless hand-over between visited access points and full traffic
+#    traceability: you will not be blamed for something a "guest" has done.
+#
+#  * Only the MAC address of your device, the IP address of your access point
+#    and information that's available in the beacon (SSID and similar) are ever
+#    sent to the server or a visited access point. No personally identifiable
+#    information, and absolutely no authentication credentials ever leave your
+#    system!
+#
+# Extensive documentation is available at http://anyfi.net/documentation.
+#
+# Overview of the integration
+# ===========================
+#
+# Anyfi.net software consists of two user space daemons; the radio frontend
+# daemon anyfid and the tunnel termination backend daemon myfid. They
+# communicate with each other and a mobility control server to orchestrate the
+# seamless user experience.
+#
+# The frontend daemon anyfid listens on a monitor interface to detect when
+# a mobile device has come within range, and dynamically allocates a virtual
+# access point for that device. Any and all Wi-Fi traffic on the virtual access
+# point is then relayed, through a Wi-Fi over IP tunnel, to the device's home
+# network. The integration is responsible for creating the monitor interface and
+# the pool of virtual access points; anyfid handles the rest.
+#
+# The tunnel termination backend daemon myfid sits on the other side of the
+# Wi-Fi over IP tunnel, making it possible to connect remotely to the local
+# Wi-Fi network. It is up to the integration to configure myfid to authenticate
+# remote devices with the same credentials that are used to authenticate devices
+# locally. This is key to the seamless user experience.
+#
+# Myfid is also responsible for registering in the server the MAC address of
+# devices that connect locally, so that they will automatically be offered
+# remote access whenever they come close to an access point running anyfid.
+# However, when the user changes the WPA passphrase all associations between
+# previously connected devices and the local Wi-Fi network should be removed.
+# The integration does so by starting myfid with the --reset flag in this case.
+#
+# Below is the integration logic in pseudo code. If you need to integrate
+# Anyfi.net software in your own firmware build environment you can find step by
+# step instructions at http://anyfi.net/integration.
+#
+# After enabling a Wi-Fi device:
+#   IF Anyfi.net server is configured AND Anyfi.net is not disabled
+#     ALLOCATE monitor interface and virtual access point pool for anyfid
+#     START anyfid
+#
+#   FOREACH Wi-Fi interface of this device
+#     IF Anyfi.net server is configured AND Anyfi.net is not disabled
+#      GENERATE a config file for myfid
+#
+#      IF the WPA passphrase has changed
+#        ADD the --reset flag to myfid arguments
+#
+#      START myfid on the Wi-Fi interface
+# 
+# After disabling a Wi-Fi device:
+#   STOP anyfid
+#
+#   FOREACH Wi-Fi interface of this device
+#     STOP myfid on the Wi-Fi interface
+#
+# NOTE1: The integration provides remote access to all Wi-Fi interfaces on the
+#        system that have "anyfi_server" configured. Each interface will have
+#        its own myfid daemon. There should however only be one anyfid daemon
+#        per radio.
+#
+# NOTE2: On concurrent dual band routers each radio should have its own anyfid
+#        daemon.
+
+append ENABLE_HOOKS anyfi_enable
+append DISABLE_HOOKS anyfi_disable
+
+# Daemon run dir for temporary files
+RUNDIR=/var/run
+
+# Config file dir for persistent configuration files
+CONFDIR=/etc
+
+# Daemon log level 0-4 (debug only)
+ANYFI_DEBUG=0
+
+# Setup monitor/vap interfaces
+# anyfi_dev_prepare <device> 
+anyfi_dev_prepare() {
+	local device="$1"
+	local type phy macaddr vifs
+	local nvaps idx
+
+	config_get type    "$device" type
+	config_get phy     "$device" phy
+	config_get macaddr "$device" macaddr
+	config_get vifs    "$device" vifs
+
+	if [ "$type" != mac80211 ]; then
+		echo "This Anyfi.net frontend integration only supports mac80211. Please contact" 1>&2
+		echo "support@anyfi.net for access to integrations for proprietary drivers from" 1>&2
+		echo "Broadcom, Atheros, Ralink, etc." 1>&2
+		return 1
+	fi
+
+	# Create monitor interface
+	local mon="$(anyfi_dev_monitor_name $device)"
+	[ -n "$phy" ] && [ -n "$mon" ] || {
+		echo "Could not allocate monitor interface for anyfid" 1>&2
+		return 1
+	}
+	if ! ifconfig $mon > /dev/null 2>&1; then
+		iw phy $phy interface add $mon type monitor
+	fi
+
+	# Create pool of virtual access point interfaces
+	# Use at least 4 virtual APs but try to keep number of beacons below 8
+	local nvifs=$(echo $vifs | wc -w)
+	if [ $nvifs -lt 4 ]
+	then
+		nvaps=$((8-$nvifs))
+	else
+		nvaps=4
+	fi
+	for idx in $(seq 0 $(($nvaps-1))); do
+		local vap="$(anyfi_dev_vap_name $device $idx)"
+		iw phy $phy interface add $vap type __ap
+		local mac="$(mac80211_generate_mac $(($nvifs + $idx)) $macaddr $(cat /sys/class/ieee80211/${phy}/address_mask))"
+		ifconfig $vap hw ether $mac
+	done
+
+	IF_START=$(anyfi_dev_vap_name $device 0)
+	IF_COUNT=$nvaps
+}
+
+# Get monitor name based on device
+# anyfi_dev_monitor_name <device>
+anyfi_dev_monitor_name() {
+	local device="$1"
+
+	# Map radioX => monitorX	
+	echo $device | sed 's/^.*\([0-9]\)$/monitor\1/'
+}
+
+# Get name of vap interface based on device and vap index
+# anyfi_dev_vap_name <device> <index>
+anyfi_dev_vap_name() {
+	local device="$1"
+	local idx="$2"
+
+	# Map radioX => anyfiX-{0,1,2,3...}
+	echo "$(echo $device | sed 's/^.*\([0-9]\)$/anyfi\1-/')${idx}"
+}
+
+# Get the device channel
+# anyfi_dev_channel <device>
+anyfi_dev_channel() {
+	local device="$1"
+	local hwmode channel
+
+	config_get hwmode  "$device" hwmode
+	config_get channel "$device" channel
+
+	if [ "$channel" = auto -o "$channel" = 0 ]; then
+		case "$hwmode" in
+		auto)
+			echo "auto"
+			return;;
+
+		*b*|*g*)
+			echo "auto2"
+			return;;
+
+		*a*)
+			echo "auto5"
+			return;;
+		esac
+	fi
+
+	echo "$channel"
+}
+
+# Start the Anyfi.net frontend daemon anyfid on a device
+# anyfi_dev_start <device> <server>
+anyfi_dev_start()
+{
+	local device="$1"
+	local server="$2"
+
+	# ALLOCATE monitor and pool of virtual access points
+	if anyfi_dev_prepare $device; then
+		local mon="$(anyfi_dev_monitor_name $device)"
+		local args=""
+
+		local vifs floor ceiling uplink downlink port
+
+		config_get vifs     "$device" vifs
+		config_get floor    "$device" anyfi_floor
+		config_get ceiling  "$device" anyfi_ceiling
+		config_get uplink   "$device" anyfi_uplink
+		config_get downlink "$device" anyfi_downlink
+		config_get port     "$device" anyfi_port
+
+		# If there are no interfaces on this device then anyfid controls channel
+		[ $(echo $vifs | wc -w) -eq 0 ] && args="$args --channel=$(anyfi_dev_channel $device)"
+
+		[ -n "$floor"    ] && args="$args --floor=$floor"
+		[ -n "$ceiling"  ] && args="$args --ceiling=$ceiling"
+		[ -n "$uplink"   ] && args="$args --uplink=$uplink"
+		[ -n "$downlink" ] && args="$args --downlink=$downlink"
+		[ -n "$port"     ] && args="$args --bind-port=$port"
+
+		# START anyfid
+		echo "Starting Anyfi.net frontend daemon anyfid on $device"
+		anyfid --accept-license -s "$server" -B \
+		       -P $RUNDIR/anyfid_$device.pid -v $ANYFI_DEBUG \
+		       $args $mon $IF_START/$IF_COUNT
+	fi
+}
+
+# Generate the config file for myfid from UCI variables
+# anyfi_vif_gen_config <iface>
+anyfi_vif_gen_config() {
+	local iface="$1"
+
+	local type net ssid enc key ifname uuid
+
+	config_get type   "$iface"  type
+	config_get net    "$iface"  network
+	config_get ssid   "$iface"  ssid
+	config_get enc    "$iface"  encryption
+	config_get key    "$iface"  key
+	config_get ifname "$iface"  ifname
+	config_get uuid   "$iface"  anyfi_uuid
+
+	# Check basic settings before proceeding
+	[ -n "$net" ] || [ -n "$ssid" ] || return 1
+
+	local auth_proto auth_mode auth_cache group_rekey
+	local ciphers wpa_ciphers rsn_ciphers
+	local passphrase
+	local auth_server auth_port auth_secret
+	local acct_server acct_port acct_secret
+	local radius_nasid
+
+	# Resolve explicit cipher overrides (tkip, ccmp or tkip+ccmp)
+	case "$enc" in
+	*+tkip+ccmp|*+tkip+aes)
+		ciphers=tkip+ccmp
+		;;
+
+	*+ccmp|*+aes)
+		ciphers=ccmp
+		;;
+
+	*+tkip)
+		ciphers=tkip
+		;;
+	esac
+
+	# Resolve authentication protocol (WPA or WPA2)
+	case "$enc" in
+	psk-mixed*|wpa-mixed*)
+		auth_proto=wpa+rsn
+		wpa_ciphers=$ciphers
+		rsn_ciphers=$ciphers
+		;;
+
+	psk2*|wpa2*)
+		auth_proto=rsn
+		rsn_ciphers=$ciphers
+		;;
+
+	psk*|wpa*)
+		auth_proto=wpa
+		wpa_ciphers=$ciphers
+		;;
+		
+	none)
+		auth_proto=open
+		if [ "$type" != any80211 ]; then
+			echo "Anyfi.net backend does not allow open networks with $type driver" 1>&2
+			return 1
+		fi
+		;;
+
+	wep*)
+		echo 'Anyfi.net does not provide remote access to WEP networks for security reasons' 1>&2
+		return 1
+		;;
+
+	*)
+		echo 'Unrecognized encryption type' 1>&2
+		return 1
+		;;
+	esac
+
+	# Resolve authenticator mode (PSK or 802.1X)
+	case "$enc" in
+	psk*)
+		auth_mode=psk
+
+		passphrase=$key
+
+		[ -n "$passphrase"  ] || return 1
+		;;
+
+	wpa*)
+		auth_mode=eap
+
+		config_get auth_server "$iface"  auth_server
+		config_get auth_port   "$iface"  auth_port
+		config_get auth_secret "$iface"  auth_secret
+
+		config_get acct_server "$iface"  acct_server
+		config_get acct_port   "$iface"  acct_port
+		config_get acct_secret "$iface"  acct_secret
+
+		config_get auth_cache  "$iface"  auth_cache
+		config_get group_rekey "$iface"  wpa_group_rekey
+		config_get auth_nasid  "$iface"  radius_nasid
+
+		[ -n "$auth_server" ] || return 1
+		[ -n "$auth_port"   ] || auth_port=1812
+		[ -n "$auth_secret" ] || auth_secret=$key
+
+		[ -n "$acct_server" -a -z "$acct_port"   ] && acct_port=1813
+		[ -n "$acct_server" -a -z "$acct_secret" ] && acct_secret=$key
+		;;
+
+	none)
+		;;
+
+	*)
+		echo "Anyfi.net backend requires explicit 'encryption' configuration" 1>&2
+		return 1
+		;;
+	esac
+
+	# Generate common config file options
+	cat <<EOF
+ssid = '$ssid'
+bridge = br-$net
+auth_proto = $auth_proto
+EOF
+
+	# Generate dependent config file options
+	[ -n "$auth_mode"    ] && echo "auth_mode = $auth_mode"
+	[ -n "$auth_cache"   ] && echo "auth_cache = $auth_cache"
+	[ -n "$rsn_ciphers"  ] && echo "rsn_ciphers = $rsn_ciphers"
+	[ -n "$wpa_ciphers"  ] && echo "wpa_ciphers = $wpa_ciphers"
+	[ -n "$group_rekey"  ] && echo "group_rekey = $group_rekey"
+	[ -n "$uuid"         ] && echo "uuid = $uuid"
+	[ -n "$ifname"       ] && echo "local_ap = $ifname"
+	[ -n "$passphrase"   ] && echo "passphrase = '$passphrase'"
+	[ -n "$auth_server"  ] && echo "radius_auth_server = $auth_server"
+	[ -n "$auth_port"    ] && echo "radius_auth_port = $auth_port"
+	[ -n "$auth_secret"  ] && echo "radius_auth_secret = $auth_secret"
+	[ -n "$acct_server"  ] && echo "radius_acct_server = $acct_server"
+	[ -n "$acct_port"    ] && echo "radius_acct_port = $acct_port"
+	[ -n "$acct_secret"  ] && echo "radius_acct_secret = $acct_secret"
+	[ -n "$radius_nasid" ] && echo "radius_nasid = $radius_nasid"
+
+	return 0
+}
+
+# Get a config value from a configuration file for myfid
+# anyfi_vif_config_get <file> <config>
+anyfi_vif_config_get() {
+	local file="$1"
+	local key="$2"
+
+	[ -e "$file" ] || return 1
+
+	# Assume the format is exactly "key = value" (where value may or may not be in '')
+	grep "$key = " $file | cut -d '=' -f2- | cut -b2- | sed -e "/^'.*'$/s/^'\\(.*\\)'$/\\1/"
+}
+
+# Start the Anyfi.net backend daemon myfid on an interface
+# anyfi_vif_start <iface> <server>
+anyfi_vif_start()
+{
+	local iface="$1"
+	local server="$2"
+	local ifname key
+
+	config_get ifname  "$iface"  ifname
+	config_get key	   "$iface"  key
+
+	local pid_file="$RUNDIR/myfid_${ifname:-$iface}.pid"
+	local conf_file="$CONFDIR/myfid_${ifname:-$iface}.conf"
+	local new_conf_file="$RUNDIR/myfid_${ifname:-$iface}.conf"
+
+	# GENERATE a config file for myfid
+	if (anyfi_vif_gen_config $iface) > $new_conf_file; then
+		local port
+		local args=""
+
+		config_get port "$iface" anyfi_port
+
+		[ -n "$port" ] && args="$args --bind-port=$port"
+
+		if [ -e "$conf_file" ]; then
+			# Get old passphrase
+			local old_key="$(anyfi_vif_config_get $conf_file passphrase)"
+
+			# ADD the --reset flag to myfid arguments if passphrase has changed
+			[ "$key" == "$old_key" ] || args="$args --reset"
+		fi
+
+		# Update the myfid config file in flash only if needed
+		if ! cmp -s $new_conf_file $conf_file ; then
+			mv $new_conf_file $conf_file
+		else
+			rm -f $new_conf_file
+		fi
+
+		# START myfid
+		echo "Starting Anyfi.net backend daemon myfid on ${ifname:-$iface}"
+		myfid --accept-license -s "$server" -B -P $pid_file -v $ANYFI_DEBUG $args $conf_file
+	fi
+}
+
+# Run from ENABLE_HOOKS
+anyfi_enable()
+{
+	local device="$1"
+	local server disabled
+	local vifs
+
+	config_get server   "$device" anyfi_server
+	config_get disabled "$device" anyfi_disabled
+	config_get vifs     "$device" vifs
+
+	if [ -n "$server" -a "$disabled" != "1" ]; then
+		anyfi_dev_start $device "$server"
+	fi
+
+	# FOREACH Wi-Fi interface of this device
+	for vif in $vifs; do
+		config_get server "$vif" anyfi_server
+		config_get disabled "$vif" anyfi_disabled
+		if [ -n "$server" -a "$disabled" != "1" ]; then
+			anyfi_vif_start $vif "$server"
+		fi
+	done
+}
+
+# Stop an Anyfi.net daemon gracefully
+# anyfi_stop_daemon <pidfile>
+anyfi_stop_daemon() {
+	local pidfile="$1"
+
+	kill -TERM $(cat $pidfile)
+
+	for t in $(seq 0 5); do
+		[ -e $pidfile ] || return 0
+		sleep 1
+	done
+
+	echo "Timeout waiting for daemon to exit and $pidfile to be removed" 1>&2
+	kill -KILL $(cat $pidfile)
+	rm -f $pidfile
+	return 1
+}
+
+# Undo what anyfi_dev_prepare did
+# anyfi_dev_unprepare <device>
+anyfi_dev_unprepare() {
+
+	local device="$1"
+
+	# Take down monitor interface	
+	local mon="$(anyfi_dev_monitor_name $device)"
+	if ifconfig "$mon" down > /dev/null 2>&1; then
+		iw "$mon" del
+	fi	
+
+	# Take down vaps
+	for idx in $(seq 0 8); do
+		local vap="$(anyfi_dev_vap_name $device $idx)"
+		if ifconfig $vap > /dev/null 2>&1; then
+			ifconfig $vap down
+			iw  del
+		fi
+	done 
+
+}
+
+# Run from DISABLE_HOOKS
+anyfi_disable()
+{ 
+	local device="$1"
+
+	# STOP anyfid
+	if [ -e $RUNDIR/anyfid_$device.pid ]; then
+		echo "Stopping Anyfi.net frontend daemon anyfid on $device"
+		anyfi_stop_daemon $RUNDIR/anyfid_$device.pid
+		anyfi_dev_unprepare $device
+	fi
+
+	# FOREACH Wi-Fi interface of this device (with myfid running)
+	for pidfile in $RUNDIR/myfid_*.pid; do
+		# STOP myfid
+		if [ -e $pidfile ]; then
+			local ifname=$(echo $pidfile | sed -e 's/^.*myfid_\(.*\)\.pid/\1/')
+			echo "Stopping Anyfi.net backend daemon myfid on ${ifname}"
+			anyfi_stop_daemon $pidfile
+		fi
+	done
+}

--- a/patches/anyfi/openwrt/01-add-wifi-hooks.patch
+++ b/patches/anyfi/openwrt/01-add-wifi-hooks.patch
@@ -1,0 +1,35 @@
+Index: package/base-files/files/sbin/wifi
+===================================================================
+--- package/base-files/files/sbin/wifi	(revision 36422)
++++ package/base-files/files/sbin/wifi	(working copy)
+@@ -95,6 +95,13 @@
+ 	config_set "$device" hwmode "$hwmode"
+ }
+ 
++run_hooks() {
++	local arg="$1"; shift
++	for func in "$@"; do
++		eval "$func $arg"
++	done
++}
++
+ wifi_updown() {
+ 	[ enable = "$1" ] && {
+ 		wifi_updown disable "$2"
+@@ -110,6 +117,7 @@
+ 		if eval "type ${1}_$iftype" 2>/dev/null >/dev/null; then
+ 			eval "scan_$iftype '$device'"
+ 			eval "${1}_$iftype '$device'" || echo "$device($iftype): ${1} failed"
++			eval "run_hooks '$device' \$$(echo ${1} | tr 'a-z' 'A-Z')_HOOKS"
+ 		else
+ 			echo "$device($iftype): Interface type not supported"
+ 		fi
+@@ -193,6 +201,8 @@
+ 
+ DEVICES=
+ DRIVERS=
++ENABLE_HOOKS=
++DISABLE_HOOKS=
+ include /lib/wifi
+ scan_wifi
+ 

--- a/patches/anyfi/package/mac80211/150-mac80211-decrypt-after-ps-handling.patch
+++ b/patches/anyfi/package/mac80211/150-mac80211-decrypt-after-ps-handling.patch
@@ -1,0 +1,33 @@
+Author: Johan Almbladh <johan@anyfi.net>
+Date:   Thu May 16 10:51:48 2013 +0200
+
+    mac80211: perform power save processing even if no encryption key is set
+    
+    Thanks to the low-level interface and monitor mode packet injection it is
+    relatively straightforward to implement "thin" access points with mac80211
+    There is however one tiny obstacle; encrypted frames do not go through the
+    power save processing when the encryption keys are not available. This means
+    either the encryption keys must be transfered from the 802.1X authenticator
+    (which in a split-mac architecture is usually somewhere else in the network)
+    to the access point, or the stack must be modified to perform power save
+    processing on encrypted frames in this case. This patch takes the latter
+    approach, enabling power save processing for encrypted frames by slightly
+    reordering the RX handlers.
+
+    Signed-off-by: Johan Almbladh <johan@anyfi.net>
+
+diff -urN --show-c-function compat-wireless-2012-09-07-before_reorder_rxhs/net/mac80211/rx.c compat-wireless-2012-09-07-after_reorder_rxhs/net/mac80211/rx.c
+--- compat-wireless-2012-09-07-before_reorder_rxhs/net/mac80211/rx.c	2013-05-20 17:08:40.893220498 +0200
++++ compat-wireless-2012-09-07-after_reorder_rxhs/net/mac80211/rx.c	2013-05-20 17:09:28.649222063 +0200
+@@ -2685,10 +2685,10 @@ static void ieee80211_rx_handlers(struct
+ 		 */
+ 		rx->skb = skb;
+ 
+-		CALL_RXH(ieee80211_rx_h_decrypt)
+ 		CALL_RXH(ieee80211_rx_h_check_more_data)
+ 		CALL_RXH(ieee80211_rx_h_uapsd_and_pspoll)
+ 		CALL_RXH(ieee80211_rx_h_sta_process)
++		CALL_RXH(ieee80211_rx_h_decrypt)
+ 		CALL_RXH(ieee80211_rx_h_defragment)
+ 		CALL_RXH(ieee80211_rx_h_michael_mic_verify)
+ 		/* must be after MMIC verify so header is counted in MPDU mic */

--- a/patches/anyfi/package/mac80211/570-mac80211-add-radiotap-airtime.patch
+++ b/patches/anyfi/package/mac80211/570-mac80211-add-radiotap-airtime.patch
@@ -1,0 +1,162 @@
+Author: Johan Almbladh <johan@anyfi.net>
+Date:   Mon May 20 18:46:02 2013 +0200
+
+    mac80211: add support for reporting frame airtime use in radiotap
+
+    The radiotap capture header supported by mac80211 provides some radio-level
+    information on received frames such as bitrate and signal level. This is
+    often sufficient for sniffer applications. With accurate airtime statistics
+    it is possible to implement true "airtime fairness" bandwidth scheduling as
+    a userspace daemon, a feature often available in commercial enterprise-grade
+    access points.
+
+    This patch adds support for reporting radio airtime use in microseconds per
+    frame in the radiotap header.
+
+    Signed-off-by: Johan Almbladh <johan@anyfi.net>
+
+diff -urpN compat-wireless-2012-09-07-before-airtime/include/net/ieee80211_radiotap.h compat-wireless-2012-09-07-after-airtime/include/net/ieee80211_radiotap.h
+--- compat-wireless-2012-09-07-before-airtime/include/net/ieee80211_radiotap.h	2012-09-08 11:59:50.000000000 +0200
++++ compat-wireless-2012-09-07-after-airtime/include/net/ieee80211_radiotap.h	2013-05-20 17:46:05.812055518 +0200
+@@ -186,6 +186,10 @@ struct ieee80211_radiotap_header {
+  * IEEE80211_RADIOTAP_AMPDU_STATUS	u32, u16, u8, u8	unitless
+  *
+  *	Contains the AMPDU information for the subframe.
++ *
++ * IEEE80211_RADIOTAP_AIRTIME           __le16       usecs
++ *
++ *     The number of microseconds of airtime used to transfer this packet.
+  */
+ enum ieee80211_radiotap_type {
+ 	IEEE80211_RADIOTAP_TSFT = 0,
+@@ -210,6 +214,7 @@ enum ieee80211_radiotap_type {
+ 	IEEE80211_RADIOTAP_MCS = 19,
+ 	IEEE80211_RADIOTAP_AMPDU_STATUS = 20,
+ 
++	IEEE80211_RADIOTAP_AIRTIME = 28,
+ 	/* valid in every it_present bitmap, even vendor namespaces */
+ 	IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE = 29,
+ 	IEEE80211_RADIOTAP_VENDOR_NAMESPACE = 30,
+diff -urpN compat-wireless-2012-09-07-before-airtime/include/net/mac80211.h compat-wireless-2012-09-07-after-airtime/include/net/mac80211.h
+--- compat-wireless-2012-09-07-before-airtime/include/net/mac80211.h	2013-05-20 17:28:42.194880495 +0200
++++ compat-wireless-2012-09-07-after-airtime/include/net/mac80211.h	2013-05-20 17:46:24.084146124 +0200
+@@ -539,6 +539,7 @@ struct ieee80211_tx_rate {
+  * @ampdu_len: number of aggregated frames.
+  * 	relevant only if IEEE80211_TX_STAT_AMPDU was set.
+  * @ack_signal: signal strength of the ACK frame
++ * @tx_usecs: airtime used to tx this frame
+  */
+ struct ieee80211_tx_info {
+ 	/* common information */
+@@ -573,7 +574,8 @@ struct ieee80211_tx_info {
+ 			u8 ampdu_ack_len;
+ 			u8 ampdu_len;
+ 			u8 antenna;
+-			/* 21 bytes free */
++			u16 tx_usecs;
++			/* 18 bytes free */
+ 		} status;
+ 		struct {
+ 			struct ieee80211_tx_rate driver_rates[
+@@ -1252,6 +1254,9 @@ struct ieee80211_tx_control {
+  * @IEEE80211_HW_P2P_DEV_ADDR_FOR_INTF: Use the P2P Device address for any
+  *	P2P Interface. This will be honoured even if more than one interface
+  *	is supported.
++ *
++ * @IEEE80211_HW_REPORTS_AIRTIME: The driver will include in the TX status
++ *      report an estimate of the radio time used to transmit the frame.
+  */
+ enum ieee80211_hw_flags {
+ 	IEEE80211_HW_HAS_RATE_CONTROL			= 1<<0,
+@@ -1280,6 +1285,7 @@ enum ieee80211_hw_flags {
+ 	IEEE80211_HW_TX_AMPDU_SETUP_IN_HW		= 1<<23,
+ 	IEEE80211_HW_SCAN_WHILE_IDLE			= 1<<24,
+ 	IEEE80211_HW_P2P_DEV_ADDR_FOR_INTF		= 1<<25,
++	IEEE80211_HW_REPORTS_AIRTIME			= 1<<26,
+ };
+ 
+ /**
+@@ -2779,7 +2785,7 @@ static inline int ieee80211_sta_ps_trans
+  * The TX headroom reserved by mac80211 for its own tx_status functions.
+  * This is enough for the radiotap header.
+  */
+-#define IEEE80211_TX_STATUS_HEADROOM	14
++#define IEEE80211_TX_STATUS_HEADROOM	16
+ 
+ /**
+  * ieee80211_sta_set_buffered - inform mac80211 about driver-buffered frames
+diff -urpN compat-wireless-2012-09-07-before-airtime/net/mac80211/status.c compat-wireless-2012-09-07-after-airtime/net/mac80211/status.c
+--- compat-wireless-2012-09-07-before-airtime/net/mac80211/status.c	2013-05-20 17:28:42.090879983 +0200
++++ compat-wireless-2012-09-07-after-airtime/net/mac80211/status.c	2013-05-20 17:47:11.876383114 +0200
+@@ -228,7 +228,8 @@ static void ieee80211_set_bar_pending(st
+ 	tid_tx->bar_pending = true;
+ }
+ 
+-static int ieee80211_tx_radiotap_len(struct ieee80211_tx_info *info)
++static int ieee80211_tx_radiotap_len(struct ieee80211_local *local,
++				     struct ieee80211_tx_info *info)
+ {
+ 	int len = sizeof(struct ieee80211_radiotap_header);
+ 
+@@ -248,10 +249,18 @@ static int ieee80211_tx_radiotap_len(str
+ 	    info->status.rates[0].flags & IEEE80211_TX_RC_MCS)
+ 		len += 3;
+ 
++	/* IEEE80211_RADIOTAP_AIRTIME */
++	if (local->hw.flags & IEEE80211_HW_REPORTS_AIRTIME) {
++		len += (len & 1);
++
++		len += 2;
++	}
++
+ 	return len;
+ }
+ 
+-static void ieee80211_add_tx_radiotap_header(struct ieee80211_supported_band
++static void ieee80211_add_tx_radiotap_header(struct ieee80211_local *local,
++					     struct ieee80211_supported_band
+ 					     *sband, struct sk_buff *skb,
+ 					     int retry_count, int rtap_len)
+ {
+@@ -322,6 +331,13 @@ static void ieee80211_add_tx_radiotap_he
+ 		pos += 3;
+ 	}
+ 
++	/* IEEE80211_RADIOTAP_AIRTIME */
++	if (local->hw.flags & IEEE80211_HW_REPORTS_AIRTIME) {
++		rthdr->it_present |= cpu_to_le32(1 << IEEE80211_RADIOTAP_AIRTIME);
++		pos += ((uintptr_t)pos & 1);
++		*(__le16 *)pos = cpu_to_le16(info->status.tx_usecs);
++		pos += 2;
++	}
+ }
+ 
+ static void ieee80211_report_used_skb(struct ieee80211_local *local,
+@@ -603,13 +619,14 @@ void ieee80211_tx_status(struct ieee8021
+ 	}
+ 
+ 	/* send frame to monitor interfaces now */
+-	rtap_len = ieee80211_tx_radiotap_len(info);
++	rtap_len = ieee80211_tx_radiotap_len(local, info);
+ 	if (WARN_ON_ONCE(skb_headroom(skb) < rtap_len)) {
+ 		pr_err("ieee80211_tx_status: headroom too small\n");
+ 		dev_kfree_skb(skb);
+ 		return;
+ 	}
+-	ieee80211_add_tx_radiotap_header(sband, skb, retry_count, rtap_len);
++	ieee80211_add_tx_radiotap_header(local, sband, skb, retry_count,
++					 rtap_len);
+ 
+ 	/* XXX: is this sufficient for BPF? */
+ 	skb_set_mac_header(skb, 0);
+diff -urpN compat-wireless-2012-09-07-before-airtime/net/wireless/radiotap.c compat-wireless-2012-09-07-after-airtime/net/wireless/radiotap.c
+--- compat-wireless-2012-09-07-before-airtime/net/wireless/radiotap.c	2012-09-08 11:59:50.000000000 +0200
++++ compat-wireless-2012-09-07-after-airtime/net/wireless/radiotap.c	2013-05-20 17:47:34.708496327 +0200
+@@ -43,6 +43,7 @@ static const struct radiotap_align_size
+ 	[IEEE80211_RADIOTAP_DATA_RETRIES] = { .align = 1, .size = 1, },
+ 	[IEEE80211_RADIOTAP_MCS] = { .align = 1, .size = 3, },
+ 	[IEEE80211_RADIOTAP_AMPDU_STATUS] = { .align = 4, .size = 8, },
++	[IEEE80211_RADIOTAP_AIRTIME] = { .align = 2, .size = 2, },
+ 	/*
+ 	 * add more here as they are defined in radiotap.h
+ 	 */

--- a/patches/anyfi/package/mac80211/571-ath9k-report-airtime-on-txstatus.patch
+++ b/patches/anyfi/package/mac80211/571-ath9k-report-airtime-on-txstatus.patch
@@ -1,0 +1,174 @@
+Author: Johan Almbladh <johan@anyfi.net>
+Date:   Mon May 20 18:46:02 2013 +0200
+
+    ath9k: add support for reporting radio time used to transmit frame
+
+    The radiotap capture header supported by mac80211 provides some radio-level
+    information on received frames such as bitrate and signal level. This is
+    often sufficient for sniffer applications. With accurate airtime statistics
+    it is possible to implement true "airtime fairness" bandwidth scheduling as
+    a userspace daemon, a feature often available in commercial enterprise-grade
+    access points.
+
+    This patch adds support for reporting radio airtime use in microseconds per
+    frame back to mac80211, taking all retransmissions - both hardware and
+    software - into account.
+
+    Signed-off-by: Johan Almbladh <johan@anyfi.net>
+
+diff -urpN compat-wireless-2012-09-07-before-airtime/drivers/net/wireless/ath/ath9k/ath9k.h compat-wireless-2012-09-07-after-airtime/drivers/net/wireless/ath/ath9k/ath9k.h
+--- compat-wireless-2012-09-07-before-airtime/drivers/net/wireless/ath/ath9k/ath9k.h	2013-05-21 14:54:14.748059030 +0200
++++ compat-wireless-2012-09-07-after-airtime/drivers/net/wireless/ath/ath9k/ath9k.h	2013-05-21 14:55:33.456061610 +0200
+@@ -223,6 +223,7 @@ struct ath_buf_state {
+ 	u8 ndelim;
+ 	u16 seqno;
+ 	unsigned long bfs_paprd_timestamp;
++	u32 bfs_tx_usecs;
+ };
+ 
+ struct ath_buf {
+diff -urpN compat-wireless-2012-09-07-before-airtime/drivers/net/wireless/ath/ath9k/init.c compat-wireless-2012-09-07-after-airtime/drivers/net/wireless/ath/ath9k/init.c
+--- compat-wireless-2012-09-07-before-airtime/drivers/net/wireless/ath/ath9k/init.c	2013-05-21 14:54:14.780059032 +0200
++++ compat-wireless-2012-09-07-after-airtime/drivers/net/wireless/ath/ath9k/init.c	2013-05-21 14:55:33.468061610 +0200
+@@ -694,7 +694,8 @@ void ath9k_set_hw_capab(struct ath_softc
+ 		IEEE80211_HW_SUPPORTS_PS |
+ 		IEEE80211_HW_PS_NULLFUNC_STACK |
+ 		IEEE80211_HW_SPECTRUM_MGMT |
+-		IEEE80211_HW_REPORTS_TX_ACK_STATUS;
++		IEEE80211_HW_REPORTS_TX_ACK_STATUS |
++		IEEE80211_HW_REPORTS_AIRTIME;
+ 
+ 	if (sc->sc_ah->caps.hw_caps & ATH9K_HW_CAP_HT)
+ 		 hw->flags |= IEEE80211_HW_AMPDU_AGGREGATION;
+diff -urpN compat-wireless-2012-09-07-before-airtime/drivers/net/wireless/ath/ath9k/xmit.c compat-wireless-2012-09-07-after-airtime/drivers/net/wireless/ath/ath9k/xmit.c
+--- compat-wireless-2012-09-07-before-airtime/drivers/net/wireless/ath/ath9k/xmit.c	2013-05-21 14:54:14.780059032 +0200
++++ compat-wireless-2012-09-07-after-airtime/drivers/net/wireless/ath/ath9k/xmit.c	2013-05-21 15:08:12.588086477 +0200
+@@ -49,6 +49,7 @@ static u16 bits_per_symbol[][2] = {
+ 
+ #define IS_HT_RATE(_rate)     ((_rate) & 0x80)
+ 
++static struct ath_frame_info *get_frame_info(struct sk_buff *skb);
+ static void ath_tx_send_normal(struct ath_softc *sc, struct ath_txq *txq,
+ 			       struct ath_atx_tid *tid, struct sk_buff *skb);
+ static void ath_tx_complete(struct ath_softc *sc, struct sk_buff *skb,
+@@ -67,6 +68,8 @@ static struct ath_buf *ath_tx_setup_buff
+ 					   struct ath_txq *txq,
+ 					   struct ath_atx_tid *tid,
+ 					   struct sk_buff *skb);
++static u32 ath_pkt_duration(struct ath_softc *sc, u8 rix, int pktlen,
++			    int width, int half_gi, bool shortPreamble);
+ 
+ enum {
+ 	MCS_HT20,
+@@ -76,6 +79,69 @@ enum {
+ };
+ 
+ /*********************/
++/*   Airtime logic   */
++/*********************/
++
++static u16 ath_sat16(u32 x)
++{
++    return x < USHRT_MAX ? x : USHRT_MAX;
++}
++
++static u32 ath_tx_compute_airtime(struct ath_softc *sc, struct ath_buf *bf,
++				  u8 band, struct ieee80211_tx_rate *rates,
++				  struct ath_tx_status *ts)
++{
++	struct ath_frame_info *fi;
++	u32 usecs = 0;
++	int i;
++	int tx_rateindex = ts->ts_rateindex;
++
++	if (tx_rateindex > 3)
++		tx_rateindex = 3;
++
++	fi = get_frame_info(bf->bf_mpdu);
++
++	for (i = 0; i <= tx_rateindex; i++) {
++		int count = (i == tx_rateindex ?
++			     ts->ts_longretry + 1 : rates[i].count);
++		bool is_sgi = !!(rates[i].flags & IEEE80211_TX_RC_SHORT_GI);
++		bool is_40 = !!(rates[i].flags & IEEE80211_TX_RC_40_MHZ_WIDTH);
++		bool is_sp = !!(rates[i].flags &
++				IEEE80211_TX_RC_USE_SHORT_PREAMBLE);
++
++		if (count <= 0)
++			continue;
++
++		if (rates[i].flags & IEEE80211_TX_RC_MCS)
++			usecs += count * ath_pkt_duration(sc, rates[i].idx,
++							  fi->framelen, is_40,
++							  is_sgi, is_sp);
++		else {
++			const struct ieee80211_rate *rate =
++				&sc->sbands[band].
++				bitrates[rates[i].idx];
++			int phy;
++			bool is_sp;
++
++			if ((band == IEEE80211_BAND_2GHZ) &&
++			    !(rate->flags & IEEE80211_RATE_ERP_G))
++				phy = WLAN_RC_PHY_CCK;
++			else
++				phy = WLAN_RC_PHY_OFDM;
++
++			is_sp = rate->hw_value_short && (rates[i].flags &
++				IEEE80211_TX_RC_USE_SHORT_PREAMBLE);
++
++			usecs += count * ath9k_hw_computetxtime(sc->sc_ah, phy,
++					   rate->bitrate * 100, fi->framelen,
++					   rates[i].idx, is_sp);
++		}
++	}
++
++	return usecs;
++}
++
++/*********************/
+ /* Aggregation logic */
+ /*********************/
+ 
+@@ -427,6 +493,9 @@ static void ath_tx_complete_aggr(struct
+ 			if (!bf->bf_stale || bf_next != NULL)
+ 				list_move_tail(&bf->list, &bf_head);
+ 
++			bf->bf_state.bfs_tx_usecs +=
++				 ath_tx_compute_airtime(sc, bf, tx_info->band, rates, ts);
++
+ 			ath_tx_complete_buf(sc, bf, txq, &bf_head, ts, 0);
+ 
+ 			bf = bf_next;
+@@ -484,6 +553,9 @@ static void ath_tx_complete_aggr(struct
+ 		tx_info = IEEE80211_SKB_CB(skb);
+ 		fi = get_frame_info(skb);
+ 
++		bf->bf_state.bfs_tx_usecs +=
++			ath_tx_compute_airtime(sc, bf, tx_info->band, rates, ts);
++
+ 		if (ATH_BA_ISSET(ba, ATH_BA_INDEX(seq_st, seqno))) {
+ 			/* transmit completion, subframe is
+ 			 * acked by block ack */
+@@ -2090,6 +2162,8 @@ static void ath_tx_complete_buf(struct a
+ 	if (ts->ts_status & ATH9K_TXERR_FILT)
+ 		tx_info->flags |= IEEE80211_TX_STAT_TX_FILTERED;
+ 
++	tx_info->status.tx_usecs = ath_sat16(bf->bf_state.bfs_tx_usecs);
++
+ 	dma_unmap_single(sc->dev, bf->bf_buf_addr, skb->len, DMA_TO_DEVICE);
+ 	bf->bf_buf_addr = 0;
+ 
+@@ -2185,6 +2259,12 @@ static void ath_tx_process_buffer(struct
+ 		txq->axq_ampdu_depth--;
+ 
+ 	if (!bf_isampdu(bf)) {
++		struct ieee80211_tx_info *tx_info =
++			IEEE80211_SKB_CB(bf->bf_mpdu);
++
++		bf->bf_state.bfs_tx_usecs += ath_tx_compute_airtime(sc, bf,
++				tx_info->band, tx_info->control.rates, ts);
++
+ 		ath_tx_rc_status(sc, bf, ts, 1, txok ? 0 : 1, txok);
+ 		ath_tx_complete_buf(sc, bf, txq, bf_head, ts, txok);
+ 	} else

--- a/products/ap/Makefile
+++ b/products/ap/Makefile
@@ -9,7 +9,8 @@ define Product/ap
 	CONFIG += \
 		CONFIG_BUSYBOX_CONFIG_TELNETD=n \
 		CONFIG_PACKAGE_wpad-mini=n \
-		CONFIG_PACKAGE_wpad=y
+		CONFIG_PACKAGE_wpad=y \
+		CONFIG_PACKAGE_anyfi=y
 
 	SETTINGS := uci-product.sh
 

--- a/products/ap/patches/anyfi/feeds/luci/luci/01-add-anyfi-web-config.patch
+++ b/products/ap/patches/anyfi/feeds/luci/luci/01-add-anyfi-web-config.patch
@@ -1,0 +1,92 @@
+--- luci-0.11+svn9672-orig/modules/admin-full/luasrc/model/cbi/admin_network/wifi.lua	2012-12-18 14:58:22.000000000 +0100
++++ luci-0.11+svn9672/modules/admin-full/luasrc/model/cbi/admin_network/wifi.lua	2013-05-20 17:06:44.580346801 +0200
+@@ -118,6 +118,7 @@ s.addremove = false
+ s:tab("general", translate("General Setup"))
+ s:tab("macfilter", translate("MAC-Filter"))
+ s:tab("advanced", translate("Advanced Settings"))
++s:tab("mobility", "Anyfi.net")
+ 
+ --[[
+ back = s:option(DummyValue, "_overview", translate("Overview"))
+@@ -377,6 +378,50 @@ if hwtype == "prism2" then
+ 	s:taboption("advanced", Value, "rxantenna", translate("Receiver Antenna"))
+ end
+ 
++------------------- Anyfi.net front-end configuration (by Anyfi Networks AB) -------------------
++
++if fs.access("/sbin/anyfid") then
++        anyfi = s:taboption("mobility", Flag, "anyfi_disabled", translate("Radio Front-End"),
++			    translate("Allow mobile devices to connect to remote Wi-Fi networks through this radio."))
++	anyfi.enabled = 0
++	anyfi.disabled = 1
++	anyfi.default = anyfi.enabled
++	anyfi.rmempty = true
++
++	floor = s:taboption("mobility", ListValue, "anyfi_floor", translate("Minimum Bandwidth"),
++			    translate("The share of total bandwidth that is always available to mobile devices."))
++	floor:value("1", "Minimal (1%)")
++	floor:value("5", "Low (5%)")
++	floor:value("10", "Medium (10%)")
++	floor:value("25", "High (25%)")
++	floor.default = "5"
++	floor:depends({anyfi_disabled="0"})
++
++	ceil = s:taboption("mobility", ListValue, "anyfi_ceiling", translate("Maximum Bandwidth"),
++			   translate("The maximum share of total bandwidth that can be allocated to mobile devices."))
++	ceil:value("25", "Minimal (25%)")
++	ceil:value("50", "Low (50%)")
++	ceil:value("75", "Medium (75%)")
++	ceil:value("100", "High (100%)")
++	ceil.default = "75"
++	ceil:depends({anyfi_disabled="0"})
++end
++
++if fs.access("/sbin/anyfid") or fs.access('/sbin/myfid') then
++	server = s:taboption("mobility", Value, "anyfi_server", translate("Mobility Control Server"))
++	server.datatype = hostname
++	server.optional = true
++
++	function server.remove(self, section)
++		self.write(self, section, "")
++	end
++	function server.write(self, section, value)
++		for _, net in ipairs(wdev:get_wifinets()) do
++			net:set("anyfi_server", value)
++		end
++		self.map:set(section, "anyfi_server", value)
++	end
++end
+ 
+ ----------------------- Interface -----------------------
+ 
+@@ -390,6 +435,7 @@ s:tab("general", translate("General Setu
+ s:tab("encryption", translate("Wireless Security"))
+ s:tab("macfilter", translate("MAC-Filter"))
+ s:tab("advanced", translate("Advanced Settings"))
++s:tab("mobility", "Anyfi.net")
+ 
+ s:taboption("general", Value, "ssid", translate("<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"))
+ 
+@@ -959,4 +1003,22 @@ if hwtype == "atheros" or hwtype == "mac
+ 	password:depends({mode="sta-wds", eap_type="ttls", encryption="wpa"})
+ end
+ 
++------------------- Anyfi.net back-end configuration (by Anyfi Networks AB) -------------------
++
++local host = server:formvalue(wdev:name()) or wdev:get("anyfi_server")
++if fs.access('/sbin/myfid') and host and host ~= "" then
++	anyfi = s:taboption("mobility", Flag, "anyfi_disabled", translate("Tunnel Termination Back-End"),
++			    translate("Enable seamless and secure remote access to this Wi-Fi network for mobile devices."))
++	anyfi.enabled = 0
++	anyfi.disabled = 1
++	anyfi.default = anyfi.enabled
++	anyfi.rmempty = true
++	anyfi:depends({mode="ap", encryption="psk"})
++	anyfi:depends({mode="ap", encryption="psk2"})
++	anyfi:depends({mode="ap", encryption="psk-mixed"})
++	anyfi:depends({mode="ap", encryption="wpa"})
++	anyfi:depends({mode="ap", encryption="wpa2"})
++	anyfi:depends({mode="ap", encryption="wpa-mixed"})
++end
++
+ return m

--- a/products/ap/uci-customization.sh
+++ b/products/ap/uci-customization.sh
@@ -4,7 +4,9 @@ MAC=$(uci get wireless.radio0.macaddr | tr 'a-f' 'A-F')
 
 # Set up wireless as open network per default
 uci delete wireless.radio0.disabled
+uci set wireless.radio0.anyfi_server=anyfi.net
 uci set wireless.@wifi-iface[0].ssid="carrierwrt-$(echo $MAC | cut -c10-17 | tr -d ':')"
+uci set wireless.@wifi-iface[0].anyfi_server=anyfi.net
 uci commit wireless
 
 # Open up firewall so that AP can be managed over WAN

--- a/products/appliance/Makefile
+++ b/products/appliance/Makefile
@@ -7,7 +7,7 @@
 
 define Product/appliance
 
-	CONFIG += 
+	CONFIG += CONFIG_PACKAGE_anyfi=y
 
 	SETTINGS := uci-product.sh
 

--- a/products/appliance/files/lib/wifi/any80211.sh
+++ b/products/appliance/files/lib/wifi/any80211.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Copyright (C) 2013 Anyfi Networks AB.
+#
+# Anyfi.net Virtual Wi-Fi Device Driver
+# =====================================
+#
+# Anyfi.net is an open Wi-Fi mobility platform that lets you seamlessly access
+# your favourite Wi-Fi networks remotely. But it can also be used for carrier
+# Wi-Fi applications. With carrier Wi-Fi you typically want to connect very
+# many devices to a central location, e.g. the mobile core or a data center.
+# This "virtual Wi-Fi device driver" lets you do that by giving you a virtual
+# radio to configure with the SSID and security settings that you want for your
+# virtual Wi-Fi network. The network will of course not have any local
+# representation (since there is no Wi-Fi radio), but can still be distributed
+# through an infinite number of Anyfi.net enabled access points.
+
+append DRIVERS "any80211"
+
+detect_any80211() {
+	local cfg
+	config_load wireless
+
+	for cfg in $CONFIG_SECTIONS; do
+		[ "$(config_get $cfg type)" = any80211 ] && return 0
+	done
+
+	cat <<EOF
+config wifi-device 'virtual0'
+	option type 'any80211'
+	option disabled '1'
+		
+config wifi-iface
+	option device 'virtual0'
+	option network 'lan'
+	option ssid 'Virtual Wi-Fi Network'
+	option encryption 'none'
+EOF
+}
+
+scan_any80211() {
+	return 0
+}
+
+enable_any80211() {
+	return 0
+}
+
+disable_any80211() {
+	return 0
+}

--- a/products/rgw/Makefile
+++ b/products/rgw/Makefile
@@ -9,7 +9,8 @@ define Product/rgw
 
 	CONFIG += \
 		CONFIG_BUSYBOX_CONFIG_TELNETD=n \
-		CONFIG_PACKAGE_luci=y
+		CONFIG_PACKAGE_luci=y \
+		CONFIG_PACKAGE_anyfi=y
 			
 	SETTINGS := uci-product.sh
 

--- a/products/rgw/patches/anyfi/feeds/luci/luci/01-add-anyfi-web-config.patch
+++ b/products/rgw/patches/anyfi/feeds/luci/luci/01-add-anyfi-web-config.patch
@@ -1,0 +1,42 @@
+--- luci-0.11+svn9672-orig/modules/admin-full/luasrc/model/cbi/admin_network/wifi.lua	2012-12-18 14:58:22.000000000 +0100
++++ luci-0.11+svn9672/modules/admin-full/luasrc/model/cbi/admin_network/wifi.lua	2013-05-20 17:11:45.117837087 +0200
+@@ -390,6 +389,7 @@ s:tab("general", translate("General Setu
+ s:tab("encryption", translate("Wireless Security"))
+ s:tab("macfilter", translate("MAC-Filter"))
+ s:tab("advanced", translate("Advanced Settings"))
++s:tab("mobility", translate("Mobility"))
+ 
+ s:taboption("general", Value, "ssid", translate("<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"))
+ 
+@@ -959,4 +957,31 @@ if hwtype == "atheros" or hwtype == "mac
+ 	password:depends({mode="sta-wds", eap_type="ttls", encryption="wpa"})
+ end
+ 
++------------------- Anyfi.net configuration (by Anyfi Networks AB) -------------------
++
++if (fs.access("/sbin/anyfid") and wdev:get("anyfi_server")) or 
++   (fs.access("/sbin/myfid") and wnet:get("anyfi_server")) then
++	anyfi = s:taboption("mobility", Flag, "anyfi_disabled", translate("Mobility"),
++			    translate("Enable seamless and secure Wi-Fi mobility."))
++	anyfi.enabled = 0
++	anyfi.disabled = 1
++	anyfi.default = anyfi.enabled
++	anyfi.rmempty = true
++	anyfi:depends({mode="ap", encryption="psk"})
++	anyfi:depends({mode="ap", encryption="psk2"})
++	anyfi:depends({mode="ap", encryption="psk-mixed"})
++
++	-- Enable save hook: enable Anyfi.net on the radio device if the interface is enabled
++	function anyfi.remove(self, section)
++		wdev:set("anyfi_disabled", nil)
++		self.map:del(section, "anyfi_disabled")
++	end
++
++	-- Disable save hook: disable Anyfi.net on the radio device if the interface is disabled
++	function anyfi.write(self, section, value)
++		wdev:set("anyfi_disabled", value)
++		self.map:set(section, "anyfi_disabled", value)
++	end
++end
++
+ return m

--- a/products/rgw/uci-customization.sh
+++ b/products/rgw/uci-customization.sh
@@ -4,9 +4,11 @@ MAC=$(uci get wireless.radio0.macaddr | tr 'a-f' 'A-F')
 
 # Set up wireless with random default passphrase
 uci delete wireless.radio0.disabled
+uci set wireless.radio0.anyfi_server=anyfi.net
 uci set wireless.@wifi-iface[0].ssid="carrierwrt-$(echo $MAC | cut -c10-17 | tr -d ':')"
 uci set wireless.@wifi-iface[0].encryption=psk-mixed
 uci set wireless.@wifi-iface[0].key="$(tr -cd 'a-zA-Z0-9' < /dev/urandom | head -c 8)"
+uci set wireless.@wifi-iface[0].anyfi_server=anyfi.net
 uci commit wireless
 
 # Set bootstrap as theme in luci

--- a/products/router/Makefile
+++ b/products/router/Makefile
@@ -8,7 +8,8 @@
 define Product/router
 
 	CONFIG += \
-		CONFIG_PACKAGE_luci=y
+		CONFIG_PACKAGE_luci=y \
+		CONFIG_PACKAGE_anyfi=y
 			
 	SETTINGS := uci-product.sh
 

--- a/products/router/patches/anyfi/feeds/luci/luci/01-add-anyfi-web-config.patch
+++ b/products/router/patches/anyfi/feeds/luci/luci/01-add-anyfi-web-config.patch
@@ -1,0 +1,42 @@
+--- luci-0.11+svn9672-orig/modules/admin-full/luasrc/model/cbi/admin_network/wifi.lua	2012-12-18 14:58:22.000000000 +0100
++++ luci-0.11+svn9672/modules/admin-full/luasrc/model/cbi/admin_network/wifi.lua	2013-05-20 17:14:41.054709505 +0200
+@@ -390,6 +389,7 @@ s:tab("general", translate("General Setu
+ s:tab("encryption", translate("Wireless Security"))
+ s:tab("macfilter", translate("MAC-Filter"))
+ s:tab("advanced", translate("Advanced Settings"))
++s:tab("mobility", translate("Mobility"))
+ 
+ s:taboption("general", Value, "ssid", translate("<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"))
+ 
+@@ -959,4 +957,31 @@ if hwtype == "atheros" or hwtype == "mac
+ 	password:depends({mode="sta-wds", eap_type="ttls", encryption="wpa"})
+ end
+ 
++------------------- Anyfi.net configuration (by Anyfi Networks AB) -------------------
++
++if (fs.access("/sbin/anyfid") and wdev:get("anyfi_server")) or
++   (fs.access("/sbin/myfid") and wnet:get("anyfi_server")) then
++	anyfi = s:taboption("mobility", Flag, "anyfi_disabled", "Anyfi.net",
++			    translate("Enable seamless and secure Wi-Fi mobility."))
++	anyfi.enabled = 0
++	anyfi.disabled = 1
++	anyfi.default = anyfi.enabled
++	anyfi.rmempty = true
++	anyfi:depends({mode="ap", encryption="psk"})
++	anyfi:depends({mode="ap", encryption="psk2"})
++	anyfi:depends({mode="ap", encryption="psk-mixed"})
++
++	-- Enable save hook: enable Anyfi.net on the radio device if the interface is enabled
++	function anyfi.remove(self, section)
++		wdev:set("anyfi_disabled", nil)
++		self.map:del(section, "anyfi_disabled")
++	end
++
++	-- Disable save hook: disable Anyfi.net on the radio device if the interface is disabled
++	function anyfi.write(self, section, value)
++		wdev:set("anyfi_disabled", value)
++		self.map:set(section, "anyfi_disabled", value)
++	end
++end
++
+ return m

--- a/products/router/uci-customization.sh
+++ b/products/router/uci-customization.sh
@@ -4,7 +4,9 @@ MAC=$(uci get wireless.radio0.macaddr | tr 'a-f' 'A-F')
 
 # Set up wireless as open network per default
 uci delete wireless.radio0.disabled
+uci set wireless.radio0.anyfi_server=anyfi.net
 uci set wireless.@wifi-iface[0].ssid="carrierwrt-$(echo $MAC | cut -c10-17 | tr -d ':')"
+uci set wireless.@wifi-iface[0].anyfi_server=anyfi.net
 uci commit wireless
 
 # Set bootstrap as theme in luci


### PR DESCRIPTION
[Anyfi.net](http://anyfi.net) is a software extension that makes every Wi-Fi network available from every access point. The user experience is completely seamless; if you have previously connected to a Wi-Fi network locally your device will automatically connect to the same network remotely whenever you come within range of another [Anyfi.net](http://anyfi.net) enabled access point.

The software consists of two user space daemons; the [radio front-end](http://anyfi.net/documentation#a_frontend) daemon **anyfid** and the [tunnel termination back-end](http://anyfi.net/documentation#a_backend) daemon **myfid**. They communicate with each other and a [mobility control server](http://anyfi.net/documentation#a_matchmaker) to orchestrate the seamless user experience.

Key features/properties:
- You don't need to install any software on the device; all the magic is on the access point side. From the device point of view it's all standard Wi-Fi.
- There is no manual registration step. When you connect your device to your home Wi-Fi network it's automatically registered for remote access to that network.
- Mobile devices "see" their favorite networks, connect automatically and authenticate using the same Wi-Fi security mechanism and credentials that where previously used to authenticate locally. This is [what makes authentication completely seamless](http://anyfi.net/documentation#a_how_it_all_fits_together).
- The Wi-Fi protocol is [tunneled over IP](http://anyfi.net/documentation#a_data_plane) from the visited access point to the home access point. This means that the encryption keys are derived only in the mobile device and in a trusted location, ensuring end-to-end security even if an attacker is in control of the visited access point. You can think of it as an automatic Wi-Fi based VPN of sorts.
- Since mobile devices connect to their home networks through a [Wi-Fi over IP tunnel](http://anyfi.net/documentation#a_data_plane) they are assigned IP addresses by the home network. This ensures seamless hand-over between visited access points and full traffic traceability: you will not be blamed for something a "guest" has done.
- Only the MAC address of your device, the IP address of your access point and information that's generally available in a beacon (SSID and similar) are ever sent to the server or a visited access point. No personally identifiable information, and absolutely no authentication credentials!
- It works both for home Wi-Fi and corporate WLANs with EAP/RADIUS authentication. The same software can also be used for [carrier Wi-Fi applications](http://www.anyfinetworks.com/solutions) such as [secure mobile offload with authentication against a SIM card](http://www.anyfinetworks.com/solutions/mobile), by simply configuring a custom [mobility control server](http://anyfi.net/documentation#a_matchmaker).

For a walkthrough of the integration please see http://anyfi.net/integration.
